### PR TITLE
MNT: tag FeatureHasher and HashingVectorizer with requires_fit=False

### DIFF
--- a/sklearn/feature_extraction/_hash.py
+++ b/sklearn/feature_extraction/_hash.py
@@ -205,4 +205,5 @@ class FeatureHasher(TransformerMixin, BaseEstimator):
             tags.input_tags.string = True
         elif self.input_type == "dict":
             tags.input_tags.dict = True
+        tags.requires_fit = False
         return tags

--- a/sklearn/feature_extraction/text.py
+++ b/sklearn/feature_extraction/text.py
@@ -914,6 +914,7 @@ class HashingVectorizer(
         tags = super().__sklearn_tags__()
         tags.input_tags.string = True
         tags.input_tags.two_d_array = False
+        tags.requires_fit = False
         return tags
 
 


### PR DESCRIPTION
#### Reference Issues/PRs
Closes https://github.com/scikit-learn/scikit-learn/issues/30689

#### What does this implement/fix? Explain your changes.
Add `requires_fit=False` within the `tags` of these estimators

#### Any other comments?
N/A